### PR TITLE
Updated logic

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -4,6 +4,8 @@ localStorage.setItem("gfgViewCount", 1);
 //removing the popup modal from DOM
 const divs = document.querySelectorAll('.login-modal-div');
 
+setTimeout(function() {
 divs.forEach(div => {
   div.remove();
 });
+}, 3000); // Timeout added if modal takes long to appear

--- a/content-script.js
+++ b/content-script.js
@@ -1,2 +1,9 @@
 // set the view count to less than 10 to avoid forcefully login
 localStorage.setItem("gfgViewCount", 1);
+
+//removing the popup modal from DOM
+const divs = document.querySelectorAll('.login-modal-div');
+
+divs.forEach(div => {
+  div.remove();
+});


### PR DESCRIPTION
This fix closes #1 

Have added a snippet to remove all divs having class name as `login-modal-div`.